### PR TITLE
Fixed missing requirement for pagination

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -11,6 +11,7 @@ description:         'A reserved <a href="http://jekyllrb.com" target="_blank">J
 url:                 http://lanyon.getpoole.com
 baseurl:             ''
 paginate:            5
+gems: ["jekyll-paginate"]
 
 # About/contact
 author:


### PR DESCRIPTION
This bit is needed in the config else it ignores the gem :fire: 